### PR TITLE
Fix the scrollbars of updates and status

### DIFF
--- a/src/content/style.scss
+++ b/src/content/style.scss
@@ -69,7 +69,7 @@ fieldset {
 
 .updates, .status {
   text-align: left;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .status {


### PR DESCRIPTION
Firefox renders `overflow: scroll;` as `overflow: auto;` for some reason, so you probably missed that